### PR TITLE
Also traverse Caption, TableHead or TableFoot 

### DIFF
--- a/jog.lua
+++ b/jog.lua
@@ -102,6 +102,14 @@ local function recurse (element, tp, jogger)
     element.head    = jogger(element.head)
     element.bodies  = jogger(element.bodies)
     element.foot    = jogger(element.foot)
+  elseif tp == 'TableHead' then
+    element.rows = jogger(element.rows)
+  elseif tp == 'TableFoot' then
+    element.rows = jogger(element.rows)
+  elseif tp == 'Row' then
+    element.cells = jogger(element.cells)
+  elseif tp == 'Cell' then
+    element.contents = jogger(element.contents)
   elseif tag == 'Figure' then
     element.caption = jogger(element.caption)
     element.content = jogger(element.content)

--- a/jog.lua
+++ b/jog.lua
@@ -102,10 +102,6 @@ local function recurse (element, tp, jogger)
     element.head    = jogger(element.head)
     element.bodies  = jogger(element.bodies)
     element.foot    = jogger(element.foot)
-  elseif tp == 'TableHead' then
-    element.rows = jogger(element.rows)
-  elseif tp == 'TableFoot' then
-    element.rows = jogger(element.rows)
   elseif tp == 'Row' then
     element.cells = jogger(element.cells)
   elseif tp == 'Cell' then
@@ -122,7 +118,8 @@ local function recurse (element, tp, jogger)
     end
   elseif tp == 'pandoc Row' then
     element.cells    = jogger(element.cells)
-  elseif tp == 'pandoc TableHead' or tp == 'pandoc TableFoot' then
+  elseif tp == 'pandoc TableHead' or tp == 'pandoc TableFoot'
+      or tp == 'TableHead' or tp == 'TableFoot' then
     element.rows    = jogger(element.rows)
   elseif tp == 'Blocks' or tp == 'Inlines' then
     local expected_itemtype = tp == 'Inlines' and 'Inline' or 'Block'

--- a/jog.lua
+++ b/jog.lua
@@ -105,6 +105,9 @@ local function recurse (element, tp, jogger)
   elseif tag == 'Figure' then
     element.caption = jogger(element.caption)
     element.content = jogger(element.content)
+  elseif tp == 'Caption' then
+    element.short = jogger(element.short)
+    element.long = jogger(element.long)
   elseif tp == 'Meta' then
     for key, value in pairs(element) do
       element[key] = jogger(value)


### PR DESCRIPTION
Traversing documents, which contain a Caption, TableHead or TableFoot element, fail with e.g. "Don't know how to traverse Caption" this PR fixes this.